### PR TITLE
Make time passage score dependent

### DIFF
--- a/resources/app.js
+++ b/resources/app.js
@@ -1753,7 +1753,7 @@ window.onload = function () {
                 if (timer.current <= 0) {
                     finishGame('timeOut');
                 }
-                timer.current -= 1;
+                timer.current -= 1 + (score.current / 3000);
             }, 1000);
         }
     }


### PR DESCRIPTION
Man this game is great! Glad I found it when I did, thanks for making this. My favorite old Android jewels no longer works on my new phone, and I need a replacement. All apps on GP are trash now, ad ridden money grab micro-transaction hell.

This is a suggestion to make the game more challenging by making available time pass faster the higher the score.

Increment value here is score divided by 3000, this means that every 3000 points a user makes, the timer moves one second faster for every second passed. In other words, at 3000 points, the time moves twice as fast as default, 2 seconds at every iteration; 3 seconds at 6000; 4 seconds at 9000, and so on.

Value was chosen arbitrarily, was just a mental estimation that "felt good". Should probably be balanced to a more grounded value.

Ideally there would be a "Difficulty" setting to adjust this.