### PR TITLE
Ability to play audio on cluster matches

### DIFF
--- a/resources/app.js
+++ b/resources/app.js
@@ -1495,6 +1495,14 @@ window.onload = function () {
                     rowOffset++;
                 }
             }
+            // Sound for cluster matches
+            if (cluster.length == 3) {
+            soundcluster3.play();	
+            } else if (cluster.length == 4) {
+            soundcluster4.play();
+            } else if (cluster.length == 5) {
+            soundcluster5.play();
+            }
         }
     }
 


### PR DESCRIPTION
Adds the ability to play a audio file to the function that loops over clusters. Different sounds can be played depending on cluster size.

This implementation example with stub code only. On its own it does nothing without first defining sound files to be played.

If this is a desirable feature, I can help search for files with an open license, that can be included with the game.